### PR TITLE
feat(keyboard): timer-based key system

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -160,6 +160,15 @@ end
 local function eventLoop()
 	while true do
 		local eventData = {os.pullEventRaw()}
+
+      -- increase key timers
+      for key in pairs(obsi.keyboard.keys) do
+         obsi.keyboard.keys[key] = obsi.keyboard.keys[key] + 1
+      end
+      for scancode in pairs(obsi.keyboard.scancodes) do
+         obsi.keyboard.scancodes[scancode] = obsi.keyboard.scancodes[scancode] + 1
+      end
+
 		if eventData[1] == "mouse_click" then
 			mouseDown(eventData[3], eventData[4], eventData[2])
 			obsi.onMousePress(eventData[3], eventData[4], eventData[2])
@@ -180,8 +189,8 @@ local function eventLoop()
 			obsi.graphics.width, obsi.graphics.height = w, h
 			obsi.onResize(w, h)
 		elseif eventData[1] == "key" and not eventData[3] then
-			obsi.keyboard.keys[keys.getName(eventData[2])] = true
-			obsi.keyboard.scancodes[eventData[2]] = true
+			obsi.keyboard.keys[keys.getName(eventData[2])] = 0
+			obsi.keyboard.scancodes[eventData[2]] = 0
 			obsi.onKeyPress(eventData[2])
 
 			-- --the code below is only for testing!
@@ -197,8 +206,8 @@ local function eventLoop()
 			-- 	obsi.debug = not obsi.debug
 			-- end
 		elseif eventData[1] == "key_up" then
-			obsi.keyboard.keys[keys.getName(eventData[2])] = false
-			obsi.keyboard.scancodes[eventData[2]] = false
+			obsi.keyboard.keys[keys.getName(eventData[2])] = nil
+			obsi.keyboard.scancodes[eventData[2]] = nil
 			obsi.onKeyRelease(eventData[2])
 		elseif eventData[1] == "terminate" or quit then
 			obsi.onQuit()

--- a/keyboard/init.lua
+++ b/keyboard/init.lua
@@ -1,18 +1,38 @@
 ---@class obsi.keyboard
 local keyboard = {}
+---@type table<string, number>
 keyboard.keys = {}
+---@type table<integer, number>
 keyboard.scancodes = {}
 
 ---@param key string
 ---@return boolean
 function keyboard.isDown(key)
-	return keyboard.keys[key] or false
+   return keyboard.keys[key] ~= nil
 end
 
 ---@param scancode integer
 ---@return boolean
 function keyboard.isScancodeDown(scancode)
-	return keyboard.scancodes[scancode] or false
+   return keyboard.scancodes[scancode] ~= nil
+end
+
+---Returns true if the user has pressed down the key in this tick, or the specified duration has
+---elapsed since pressed (in ticks).
+---@param key string
+---@param duration number?
+---@return boolean
+function keyboard.isDownNow(key, duration)
+   return keyboard.keys[key] == (duration or 0)
+end
+
+---Returns true if the user has pressed down the key in this tick, or the specified duration has
+---elapsed since pressed (in ticks).
+---@param scancode integer
+---@param duration number?
+---@return boolean
+function keyboard.isScancodeDownNow(scancode, duration)
+   return keyboard.scancodes[scancode] == (duration or 0)
 end
 
 return keyboard


### PR DESCRIPTION
This introduces a simple timer system for keyboard input. This can be used to listen to key presses (instead of firing every tick).

### Breaking changes

Use of `keyboard.keys` or `keyboard.scancodes` in user space may cause issues. I assume this to be fine, as users seemingly should use the functions instead.

### Notes

I have not changed bundle, changelog, or other parts. Consider contribution guidelines - I am unsure how to do either.
